### PR TITLE
Provide SPDX license identifier for packages

### DIFF
--- a/InkyTagHelpers/InkyTagHelpers.csproj
+++ b/InkyTagHelpers/InkyTagHelpers.csproj
@@ -10,6 +10,7 @@
     <RepositoryUrl>https://github.com/XmlmXmlmX/InkyTagHelpers</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseUrl>https://github.com/XmlmXmlmX/InkyTagHelpers/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/XmlmXmlmX/InkyTagHelpers</PackageProjectUrl>
     <PackageTags>taghelpers,aspnetcore,inky,foundation</PackageTags>
     <PackageReleaseNotes></PackageReleaseNotes>


### PR DESCRIPTION
This change adds the SPDX license identifier to the generated NuGet packages by adding the appropriate [PackageLicenseExpression](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/nuget) tag.

**Why?** Companies use the license information provided by package managers to ensure compliance across large projects. Providing an SPDX license identifier makes it simpler for people to work with automated tools like [LicenseFinder](https://github.com/pivotal/LicenseFinder) or GitLab's license scanning feature.